### PR TITLE
Allow setting the endpoint to 'nil' explicitly

### DIFF
--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -22,7 +22,7 @@ module BugsnagPerformance
 
     def endpoint
       case
-      when @endpoint
+      when defined?(@endpoint)
         # if a custom endpoint has been set then use it directly
         @endpoint
       when @api_key.nil?

--- a/spec/bugsnag_performance/configuration_spec.rb
+++ b/spec/bugsnag_performance/configuration_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe BugsnagPerformance::Configuration do
       expect(subject.endpoint).to be_nil
     end
 
+    it "is nil if set to nil" do
+      subject.api_key = "1234567890abcdef1234567890abcdef"
+      subject.endpoint = nil
+
+      expect(subject.endpoint).to be_nil
+    end
+
     it "is the default URL if API key is set" do
       subject.api_key = "1234567890abcdef1234567890abcdef"
 


### PR DESCRIPTION
Previously if `endpoint` was set to a falsey value we'd ignore it, but we should always respect the value the user has set