### PR TITLE
Add BugsnagPerformance::ConfigurationValidator

### DIFF
--- a/lib/bugsnag_performance.rb
+++ b/lib/bugsnag_performance.rb
@@ -3,3 +3,4 @@
 require_relative "bugsnag_performance/error"
 require_relative "bugsnag_performance/version"
 require_relative "bugsnag_performance/configuration"
+require_relative "bugsnag_performance/configuration_validator"

--- a/lib/bugsnag_performance/configuration_validator.rb
+++ b/lib/bugsnag_performance/configuration_validator.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module BugsnagPerformance
+  class ConfigurationValidator
+    def self.validate(configuration)
+      new(configuration).validate
+    end
+
+    def validate
+      raise MissingApiKeyError.new if @configuration.api_key.nil?
+
+      validate_api_key
+      validate_string(:app_version, optional: true)
+      validate_string(:release_stage, optional: true)
+      validate_array(:enabled_release_stages, "non-empty strings", optional: true, &method(:valid_string?))
+      validate_boolean(:use_managed_quota, optional: false)
+      valid_endpoint = validate_endpoint
+
+      # if the endpoint is invalid then we shouldn't attempt to send traces
+      Result.new(@messages, @valid_configuration, send_traces: valid_endpoint)
+    end
+
+    private
+
+    def initialize(configuration)
+      @configuration = configuration
+      @valid_configuration = BugsnagPerformance::Configuration.new
+      @messages = []
+    end
+
+    def validate_api_key
+      value = @configuration.api_key
+
+      # we always use the provided API key even if it's invalid
+      @valid_configuration.api_key = value
+
+      return if value.is_a?(String) && value =~ /\A[0-9a-f]{32}\z/i
+
+      @messages << "api_key should be a 32 character hexadecimal string, got #{value.inspect}"
+    end
+
+    def validate_string(name, optional:)
+      value = @configuration.send(name)
+
+      if (value.nil? && optional) || valid_string?(value)
+        @valid_configuration.send("#{name}=", value)
+      else
+        @messages << "#{name} should be a non-empty string, got #{value.inspect}"
+      end
+    end
+
+    def validate_boolean(name, optional:)
+      value = @configuration.send(name)
+
+      if (value.nil? && optional) || value == true || value == false
+        @valid_configuration.send("#{name}=", value)
+      else
+        @messages << "#{name} should be a boolean, got #{value.inspect}"
+      end
+    end
+
+    def validate_array(name, description, optional:, &block)
+      value = @configuration.send(name)
+
+      if (value.nil? && optional) || value.is_a?(Array) && value.all?(&block)
+        @valid_configuration.send("#{name}=", value)
+      else
+        @messages << "#{name} should be an array of #{description}, got #{value.inspect}"
+      end
+    end
+
+    def validate_endpoint
+      value = @configuration.endpoint
+
+      # we always use the provided endpoint even if it's invalid to prevent
+      # leaking data to the saas bugsnag instance
+      @valid_configuration.endpoint = value
+
+      if valid_string?(value)
+        true
+      else
+        @messages << "endpoint should be a valid URL, got #{value.inspect}"
+
+        false
+      end
+    end
+
+    def valid_string?(value)
+      value.is_a?(String) && !value.empty?
+    end
+
+    class MissingApiKeyError < Error
+      def initialize
+        super("No Bugsnag API Key set")
+      end
+    end
+
+    class Result
+      attr_reader :messages
+      attr_reader :configuration
+
+      def initialize(messages, configuration, send_traces:)
+        @messages = messages
+        @configuration = configuration.freeze
+        @send_traces = send_traces
+      end
+
+      def valid?
+        @messages.empty?
+      end
+
+      def send_traces?
+        @send_traces
+      end
+    end
+  end
+end

--- a/spec/bugsnag_performance/configuration_validator_spec.rb
+++ b/spec/bugsnag_performance/configuration_validator_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+RSpec.describe BugsnagPerformance::ConfigurationValidator do
+  subject { BugsnagPerformance::ConfigurationValidator }
+
+  let(:configuration) do
+    BugsnagPerformance::Configuration.new.tap do |configuration|
+      configuration.api_key = "abcdef1234567890abcdef1234567890"
+    end
+  end
+
+  it "is valid by default" do
+    result = subject.validate(configuration)
+
+    expect(result.messages).to be_empty
+    expect(result.valid?).to be(true)
+    expect(result.configuration.api_key).to be("abcdef1234567890abcdef1234567890")
+  end
+
+  context "API key" do
+    let(:configuration) { BugsnagPerformance::Configuration.new }
+
+    it "passes validation when set to a valid value" do
+      configuration.api_key = "abcdef1234567890abcdef1234567890"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.configuration.api_key).to be("abcdef1234567890abcdef1234567890")
+    end
+
+    it "fails validation when set to an invalid value" do
+      configuration.api_key = "oh no im not an api key :o"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'api_key should be a 32 character hexadecimal string, got "oh no im not an api key :o"',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.api_key).to be("oh no im not an api key :o")
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.api_key = 1234
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        "api_key should be a 32 character hexadecimal string, got 1234",
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.api_key).to be(1234)
+    end
+
+    it "raises when not set" do
+      expect { subject.validate(configuration) }.to raise_error(
+        BugsnagPerformance::ConfigurationValidator::MissingApiKeyError,
+        "No Bugsnag API Key set",
+      )
+    end
+  end
+
+  context "app version" do
+    it "passes validation when set to a valid value" do
+      configuration.app_version = "1.2.3"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.configuration.app_version).to be("1.2.3")
+    end
+
+    it "fails validation when set to an invalid value" do
+      configuration.app_version = ""
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'app_version should be a non-empty string, got ""',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.app_version).to be_nil
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.app_version = ["1", "2", "3"]
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'app_version should be a non-empty string, got ["1", "2", "3"]',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.app_version).to be_nil
+    end
+  end
+
+  context "release stage" do
+    it "is optional" do
+      expect(subject.validate(configuration).valid?).to be(true)
+
+      configuration.release_stage = nil
+
+      expect(subject.validate(configuration).valid?).to be(true)
+    end
+
+    it "passes validation when set to a valid value" do
+      configuration.release_stage = "production"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.configuration.release_stage).to be("production")
+    end
+
+    it "fails validation when set to an invalid value" do
+      configuration.release_stage = ""
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'release_stage should be a non-empty string, got ""',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.release_stage).to be("production")
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.release_stage = ["p", "r", "o", "d"]
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'release_stage should be a non-empty string, got ["p", "r", "o", "d"]',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.release_stage).to be("production")
+    end
+  end
+
+  context "enabled release stages" do
+    it "is optional" do
+      expect(subject.validate(configuration).valid?).to be(true)
+
+      configuration.enabled_release_stages = nil
+
+      expect(subject.validate(configuration).valid?).to be(true)
+    end
+
+    it "passes validation when set to a valid value" do
+      configuration.enabled_release_stages = ["production"]
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.configuration.enabled_release_stages).to eq(["production"])
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.enabled_release_stages = true
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        "enabled_release_stages should be an array of non-empty strings, got true",
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.enabled_release_stages).to be_nil
+    end
+  end
+
+  context "use managed quota" do
+    it "is required" do
+      configuration.use_managed_quota = nil
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        "use_managed_quota should be a boolean, got nil",
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.use_managed_quota).to be(true)
+    end
+
+    it "passes validation when set to a valid value" do
+      configuration.use_managed_quota = false
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.configuration.use_managed_quota).to be(false)
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.use_managed_quota = "falsey"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'use_managed_quota should be a boolean, got "falsey"',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.configuration.use_managed_quota).to be(true)
+    end
+  end
+
+  context "endpoint" do
+    it "is required" do
+      configuration.endpoint = nil
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        "endpoint should be a valid URL, got nil",
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.send_traces?).to be(false)
+      expect(result.configuration.endpoint).to be_nil
+    end
+
+    it "passes validation when set to a valid value" do
+      configuration.endpoint = "https://localhost:3000"
+      result = subject.validate(configuration)
+
+      expect(result.messages).to be_empty
+      expect(result.valid?).to be(true)
+      expect(result.send_traces?).to be(true)
+      expect(result.configuration.endpoint).to be("https://localhost:3000")
+    end
+
+    it "fails validation when set to an invalid type" do
+      configuration.endpoint = true
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        "endpoint should be a valid URL, got true",
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.send_traces?).to be(false)
+      expect(result.configuration.endpoint).to be(true)
+    end
+
+    it "fails validation when set to an invalid value" do
+      configuration.endpoint = ""
+      result = subject.validate(configuration)
+
+      expect(result.messages).to eq([
+        'endpoint should be a valid URL, got ""',
+      ])
+
+      expect(result.valid?).to be(false)
+      expect(result.send_traces?).to be(false)
+      expect(result.configuration.endpoint).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
Usage:

```ruby
configuration = BugsnagPerformance::Configuration.new
result = BugsnagPerformance::ConfigurationValidator.validate(configuration)

# '#valid?' and '#messages' can be used to report validation failures
# to the user
raise "Invalid configuration: #{result.messages}" unless result.valid?

# get the validated configuration object, i.e. with default values
# instead of invalid ones
validated_configuration = result.configuration

# some validation failures mean we shouldn't send any data to bugsnag,
# which can be checked using '#send_traces?'
should_send_traces = result.send_traces?
```