### PR TITLE
Use Maze Runner specific environment variables

### DIFF
--- a/features/fixtures/basic/app/app.rb
+++ b/features/fixtures/basic/app/app.rb
@@ -1,7 +1,7 @@
 require "uri"
 require "open-uri"
 
-uri = URI(ENV.fetch('BUGSNAG_PERFORMANCE_ENDPOINT'))
+uri = URI(ENV.fetch('MAZE_RUNNER_ENDPOINT'))
 uri.path = '/reflect'
 
 uri.read

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -5,5 +5,5 @@ services:
       args:
         - RUBY_TEST_VERSION
     environment:
-      - BUGSNAG_PERFORMANCE_API_KEY
-      - BUGSNAG_PERFORMANCE_ENDPOINT
+      - MAZE_RUNNER_API_KEY
+      - MAZE_RUNNER_ENDPOINT

--- a/features/support/setup_fixture_environment.rb
+++ b/features/support/setup_fixture_environment.rb
@@ -3,6 +3,6 @@ require_relative "../lib/environment"
 Maze.hooks.before do
   environment = BugsnagPerformanceMazeRunner::Environment.new
 
-  Maze::Runner.environment["BUGSNAG_PERFORMANCE_API_KEY"] = $api_key
-  Maze::Runner.environment["BUGSNAG_PERFORMANCE_ENDPOINT"] = "http://#{environment.host}:#{Maze.config.port}/traces"
+  Maze::Runner.environment["MAZE_RUNNER_API_KEY"] = $api_key
+  Maze::Runner.environment["MAZE_RUNNER_ENDPOINT"] = "http://#{environment.host}:#{Maze.config.port}"
 end


### PR DESCRIPTION
This allows us to use these environment variables in our tests without also causing the library to pre-configure itself

Previously every run had a valid API key because the library read 'BUGSNAG_PERFORMANCE_API_KEY' and that was always set

Now we have to explicitly set 'BUGSNAG_PERFORMANCE_API_KEY' in tests if we actually want to use the environment variable to configure the library