### PR TITLE
Add Configuration#configure_open_telemetry

### DIFF
--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -2,6 +2,8 @@
 
 module BugsnagPerformance
   class Configuration
+    attr_reader :open_telemetry_configure_block
+
     attr_accessor :api_key
     attr_accessor :app_version
     attr_accessor :release_stage
@@ -11,6 +13,8 @@ module BugsnagPerformance
     attr_writer :endpoint
 
     def initialize(errors_configuration)
+      @open_telemetry_configure_block = proc { |c| }
+
       @api_key = fetch(errors_configuration, :api_key, env: "BUGSNAG_PERFORMANCE_API_KEY")
       @app_version = fetch(errors_configuration, :app_version)
       @release_stage = fetch(errors_configuration, :release_stage, env: "BUGSNAG_PERFORMANCE_RELEASE_STAGE", default: "production")
@@ -36,6 +40,10 @@ module BugsnagPerformance
       else
         "https://#{@api_key}.otlp.bugsnag.com/v1/traces"
       end
+    end
+
+    def configure_open_telemetry(&open_telemetry_configure_block)
+      @open_telemetry_configure_block = open_telemetry_configure_block
     end
 
     private

--- a/lib/bugsnag_performance/configuration_validator.rb
+++ b/lib/bugsnag_performance/configuration_validator.rb
@@ -9,6 +9,7 @@ module BugsnagPerformance
     def validate
       raise MissingApiKeyError.new if @configuration.api_key.nil?
 
+      validate_open_telemetry_configure_block
       validate_api_key
       validate_string(:app_version, optional: true)
       validate_string(:release_stage, optional: true)
@@ -26,6 +27,14 @@ module BugsnagPerformance
       @configuration = configuration
       @valid_configuration = BugsnagPerformance::Configuration.new(BugsnagPerformance::NilErrorsConfiguration.new)
       @messages = []
+    end
+
+    def validate_open_telemetry_configure_block
+      value = @configuration.open_telemetry_configure_block
+
+      return if value.respond_to?(:call) && value.arity == 1
+
+      @messages << "configure_open_telemetry requires a callable with an arity of 1"
     end
 
     def validate_api_key

--- a/spec/bugsnag_performance/configuration_spec.rb
+++ b/spec/bugsnag_performance/configuration_spec.rb
@@ -17,6 +17,24 @@ end
 RSpec.describe BugsnagPerformance::Configuration do
   subject { BugsnagPerformance::Configuration.new(BugsnagPerformance::NilErrorsConfiguration.new) }
 
+  context "configure_open_telemetry" do
+    it "is callable by default" do
+      expect(subject.open_telemetry_configure_block).to respond_to(:call)
+      expect { subject.open_telemetry_configure_block.call }.not_to raise_error
+    end
+
+    it "can be configured" do
+      block = spy('configure_open_telemetry block')
+
+      # passing '&block' here raises an error so we wrap it in another block
+      subject.configure_open_telemetry { block.call }
+      expect(block).not_to have_received(:call)
+
+      subject.open_telemetry_configure_block.call
+      expect(block).to have_received(:call)
+    end
+  end
+
   context "API key" do
     it "is nil by default" do
       expect(subject.api_key).to be_nil


### PR DESCRIPTION
This stores a block that will be forwarded to `OpenTelemetry::SDK.configure`, i.e.

```ruby
module BugsnagPerformance
  def self.configure
    # ...

    OpenTelemetry::SDK.configure do |otel_configurator|
      configuration.open_telemetry_configure_block.call(otel_configurator)

      # ...
    end

    # ...
  end
end
```