### PR TITLE
Add BugsnagPerformance::Sampler

### DIFF
--- a/bugsnag-performance.gemspec
+++ b/bugsnag-performance.gemspec
@@ -31,5 +31,7 @@ Gem::Specification.new do |spec|
     end
   end
 
+  spec.add_dependency "opentelemetry-sdk", "~> 1.0"
+
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/bugsnag_performance.rb
+++ b/lib/bugsnag_performance.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "opentelemetry-sdk"
+
 require_relative "bugsnag_performance/error"
+require_relative "bugsnag_performance/sampler"
 require_relative "bugsnag_performance/version"
 require_relative "bugsnag_performance/configuration"
 require_relative "bugsnag_performance/configuration_validator"

--- a/lib/bugsnag_performance/sampler.rb
+++ b/lib/bugsnag_performance/sampler.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module BugsnagPerformance
+  class Sampler
+    PROBABILITY_SCALE_FACTOR = 18_446_744_073_709_551_615 # (2 ** 64) - 1
+
+    private_constant :PROBABILITY_SCALE_FACTOR
+
+    def initialize(probability_manager)
+      @probability_manager = probability_manager
+    end
+
+    def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
+      # NOTE: the probability could change at any time so we _must_ only read
+      #       it once in this method, otherwise we could use different values
+      #       for the sampling decision & p value attribute which would result
+      #       in inconsistent data
+      probability = @probability_manager.probability
+
+      p_value = scale_probability(probability)
+      r_value = trace_id_to_sampling_rate(trace_id)
+
+      decision =
+        if p_value >= r_value
+          OpenTelemetry::SDK::Trace::Samplers::Decision::RECORD_AND_SAMPLE
+        else
+          OpenTelemetry::SDK::Trace::Samplers::Decision::DROP
+        end
+
+      parent_span_context = OpenTelemetry::Trace.current_span(parent_context).context
+
+      OpenTelemetry::SDK::Trace::Samplers::Result.new(
+        decision: decision,
+        tracestate: parent_span_context.tracestate,
+        attributes: { "bugsnag.sampling.p" => probability },
+      )
+    end
+
+    private
+
+    def trace_id_to_sampling_rate(trace_id)
+      # unpack the trace ID as a u64
+      trace_id.unpack1("@8Q>")
+    end
+
+    def scale_probability(probability)
+      # scale the probability (stored as a float from 0-1) to a u64
+      (probability * PROBABILITY_SCALE_FACTOR).floor
+    end
+  end
+end

--- a/spec/bugsnag_performance/sampler_spec.rb
+++ b/spec/bugsnag_performance/sampler_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+class FakeProbabilityManager
+  attr_reader :probability
+
+  def initialize(probability)
+    @probability = probability
+  end
+end
+
+RSpec.describe BugsnagPerformance::Sampler do
+  let(:trace_id) { OpenTelemetry::Trace.generate_trace_id }
+  let(:tracestate) { Object.new }
+
+  let(:parent_context) do
+    span_context = OpenTelemetry::Trace::SpanContext.new(
+      trace_id: OpenTelemetry::Trace.generate_trace_id,
+      tracestate: tracestate
+    )
+
+    OpenTelemetry::Trace.context_with_span(
+      OpenTelemetry::Trace.non_recording_span(span_context)
+    )
+  end
+
+  it "should always sample with a probability of 1.0" do
+    sampler = BugsnagPerformance::Sampler.new(FakeProbabilityManager.new(1.0))
+
+    result = sampler.should_sample?(
+      trace_id: trace_id,
+      parent_context: parent_context,
+      links: nil,
+      name: nil,
+      kind: nil,
+      attributes: nil,
+    )
+
+    expect(result).to be_sampled
+    expect(result.tracestate).to be(tracestate)
+    expect(result.attributes).to eq({ "bugsnag.sampling.p" => 1.0 })
+  end
+
+  it "should never sample with a probability of 0.0" do
+    sampler = BugsnagPerformance::Sampler.new(FakeProbabilityManager.new(0.0))
+
+    result = sampler.should_sample?(
+      trace_id: trace_id,
+      parent_context: parent_context,
+      links: nil,
+      name: nil,
+      kind: nil,
+      attributes: nil,
+    )
+
+    expect(result).not_to be_sampled
+    expect(result.tracestate).to be(tracestate)
+    expect(result.attributes).to eq({ "bugsnag.sampling.p" => 0.0 })
+  end
+
+  it "should sample trace ID '2b0eb6c82ae431ad7fdc00306faebef6' with a probability of 0.5" do
+    # known value pregenerated with 'OpenTelemetry::Trace.generate_trace_id' and
+    # converted to hex for ease of reading
+    trace_id = ["2b0eb6c82ae431ad7fdc00306faebef6"].pack("H*")
+
+    sampler = BugsnagPerformance::Sampler.new(FakeProbabilityManager.new(0.5))
+
+    result = sampler.should_sample?(
+      trace_id: trace_id,
+      parent_context: parent_context,
+      links: nil,
+      name: nil,
+      kind: nil,
+      attributes: nil,
+    )
+
+    expect(result).to be_sampled
+    expect(result.tracestate).to be(tracestate)
+    expect(result.attributes).to eq({ "bugsnag.sampling.p" => 0.5 })
+  end
+
+  it "should not sample trace ID '98e03bf7fc2715bdcf426f549ca74150' with a probability of 0.5" do
+    # known value pregenerated with 'OpenTelemetry::Trace.generate_trace_id' and
+    # converted to hex for ease of reading
+    trace_id = ["98e03bf7fc2715bdcf426f549ca74150"].pack("H*")
+
+    sampler = BugsnagPerformance::Sampler.new(FakeProbabilityManager.new(0.5))
+
+    result = sampler.should_sample?(
+      trace_id: trace_id,
+      parent_context: parent_context,
+      links: nil,
+      name: nil,
+      kind: nil,
+      attributes: nil,
+    )
+
+    expect(result).not_to be_sampled
+    expect(result.tracestate).to be(tracestate)
+    expect(result.attributes).to eq({ "bugsnag.sampling.p" => 0.5 })
+  end
+
+  it "should sample roughly half of all spans with a probability of 0.5" do
+    total_spans = 50_000
+    margin_of_error = total_spans / 100
+
+    sampler = BugsnagPerformance::Sampler.new(FakeProbabilityManager.new(0.5))
+    sampled_spans = 0
+
+    total_spans.times do
+      result = sampler.should_sample?(
+        trace_id: OpenTelemetry::Trace.generate_trace_id,
+        parent_context: parent_context,
+        links: nil,
+        name: nil,
+        kind: nil,
+        attributes: nil,
+      )
+
+      sampled_spans += 1 if result.sampled?
+    end
+
+    expect(sampled_spans).to be_within(margin_of_error).of(total_spans / 2)
+  end
+end


### PR DESCRIPTION
Adds a sampler fulfilling the `Sampler` interface in the OTel SDK: https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry/SDK/Trace/Samplers