### PR TITLE
Add Delivery

### DIFF
--- a/bugsnag-performance.gemspec
+++ b/bugsnag-performance.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "opentelemetry-sdk", "~> 1.0"
 
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.23"
 end

--- a/lib/bugsnag_performance.rb
+++ b/lib/bugsnag_performance.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "net/http"
 require "concurrent-ruby"
 require "opentelemetry-sdk"
 
@@ -8,6 +9,7 @@ require_relative "bugsnag_performance/error"
 require_relative "bugsnag_performance/task"
 require_relative "bugsnag_performance/sampler"
 require_relative "bugsnag_performance/version"
+require_relative "bugsnag_performance/delivery"
 require_relative "bugsnag_performance/configuration"
 require_relative "bugsnag_performance/task_scheduler"
 require_relative "bugsnag_performance/configuration_validator"

--- a/lib/bugsnag_performance/delivery.rb
+++ b/lib/bugsnag_performance/delivery.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module BugsnagPerformance
+  class Delivery
+    def initialize(configuration)
+      @uri = URI(configuration.endpoint)
+      @common_headers = {
+        "Bugsnag-Api-Key" => configuration.api_key,
+        "Content-Type" => "application/json",
+      }.freeze
+    end
+
+    def deliver(headers, body)
+      headers = headers.merge(
+        @common_headers,
+        { "Bugsnag-Sent-At" => Time.now.utc.iso8601(3) },
+      )
+
+      raw_response = OpenTelemetry::Common::Utilities.untraced do
+        Net::HTTP.post(@uri, body, headers) rescue nil
+      end
+
+      Response.new(raw_response)
+    end
+
+    class Response
+      SAMPLING_PROBABILITY_HEADER = "Bugsnag-Sampling-Probability"
+      RETRYABLE_STATUS_CODES = Set[402, 407, 408, 429]
+
+      private_constant :SAMPLING_PROBABILITY_HEADER, :RETRYABLE_STATUS_CODES
+
+      attr_reader :state
+      attr_reader :sampling_probability
+
+      def initialize(raw_response)
+        if raw_response.nil?
+          @state = :failure_retryable
+          @sampling_probability = nil
+        else
+          @state = response_state_from_status_code(raw_response.code)
+          @sampling_probability = parse_sampling_probability(raw_response[SAMPLING_PROBABILITY_HEADER])
+        end
+      end
+
+      def successful?
+        @state == :success
+      end
+
+      def retryable?
+        @state == :failure_retryable
+      end
+
+      private
+
+      def response_state_from_status_code(raw_status_code)
+        case Integer(raw_status_code, exception: false)
+        when 200...300
+          :success
+        when RETRYABLE_STATUS_CODES
+          :failure_retryable
+        when 400...500
+          :failure_discard
+        else
+          :failure_retryable
+        end
+      end
+
+      def parse_sampling_probability(raw_probability)
+        parsed = Float(raw_probability, exception: false)
+
+        if parsed && parsed >= 0.0 && parsed <= 1.0
+          parsed
+        else
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/bugsnag_performance/delivery_spec.rb
+++ b/spec/bugsnag_performance/delivery_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe BugsnagPerformance::Delivery do
+  subject { BugsnagPerformance::Delivery.new(configuration) }
+
+  let(:configuration) do
+    BugsnagPerformance::Configuration.new(BugsnagPerformance::NilErrorsConfiguration.new).tap do |config|
+      config.api_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    end
+  end
+
+  context "#deliver" do
+    it "can deliver a payload" do
+      response = subject.deliver({ "header" => "yes" }, "hello")
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe BugsnagPerformance::Delivery::Response do
+    subject do
+      BugsnagPerformance::Delivery.new(configuration).deliver({}, "")
+    end
+
+    context "#state" do
+      context ":success" do
+        (200...300).to_a.sample(20).each do |status_code|
+          it "is :success when the status code is #{status_code}" do
+            expect(subject.state).to be(:success)
+            expect(subject).to be_successful
+            expect(subject).not_to be_retryable
+          end
+        end
+      end
+
+      context ":failure_retryable" do
+        [402, 407, 408, 429, 600, 10000, 0].each do |status_code|
+          it "is :failure_retryable when the status code is #{status_code}" do
+            stub_response_status_code(status_code)
+
+            expect(subject.state).to be(:failure_retryable)
+            expect(subject).not_to be_successful
+            expect(subject).to be_retryable
+          end
+        end
+
+        it "is :failure_retryable when there is no response" do
+          response = BugsnagPerformance::Delivery::Response.new(nil)
+
+          expect(response.state).to be(:failure_retryable)
+          expect(response).not_to be_successful
+          expect(response).to be_retryable
+        end
+      end
+
+      context ":failure_discard" do
+        ((400...500).to_a - [402, 407, 408, 429]).sample(20).each do |status_code|
+          it "is :failure_discard when the status code is #{status_code}" do
+            stub_response_status_code(status_code)
+
+            expect(subject.state).to be(:failure_discard)
+            expect(subject).not_to be_successful
+            expect(subject).not_to be_retryable
+          end
+        end
+      end
+    end
+
+    context "#sampling_probability" do
+      [0.0, 0.1, 0.25, 0.33, 0.4, 0.5, 0.66, 0.75, 0.8, 0.99, 1.0].each do |probability|
+        it "returns #{probability} if the server response is #{probability}" do
+          stub_probability_request(probability)
+
+          expect(subject.sampling_probability).to be(probability)
+        end
+      end
+
+      it "returns nil if the server response is < 0" do
+        stub_probability_request(-0.1)
+
+        expect(subject.sampling_probability).to be_nil
+      end
+
+      it "returns nil if the server response is > 1" do
+        stub_probability_request(1.001)
+
+        expect(subject.sampling_probability).to be_nil
+      end
+
+      it "returns nil if the server response is not parsable as a float" do
+        stub_probability_request(":)")
+
+        expect(subject.sampling_probability).to be_nil
+      end
+
+      it "returns nil when there is no response" do
+        response = BugsnagPerformance::Delivery::Response.new(nil)
+
+        expect(response.sampling_probability).to be_nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "webmock/rspec"
 require "bugsnag_performance"
+
+TRACES_URI = %r{\Ahttps://[0-9A-Fa-f]{32}\.otlp\.bugsnag\.com/v1/traces\z}
 
 module Helpers
   def with_environment_variable(name, value, &block)
@@ -17,6 +20,21 @@ module Helpers
     end
   end
 
+  def stub_probability_request(probability)
+    stub_request(:post, TRACES_URI).to_return(
+      body: "",
+      status: 200,
+      headers: { "Bugsnag-Sampling-Probability" => probability }
+    )
+  end
+
+  def stub_response_status_code(status_code)
+    stub_request(:post, TRACES_URI).to_return(
+      body: "",
+      status: status_code,
+    )
+  end
+
   def measure(&block)
     before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -27,11 +45,14 @@ module Helpers
 end
 
 RSpec.configure do |config|
+  config.order = :random
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+  config.filter_run_when_matching(:focus)
 
   # make rspec display colour on CI
   if ENV["CI"] == "true"
@@ -44,4 +65,8 @@ RSpec.configure do |config|
   end
 
   config.include(Helpers)
+
+  config.before(:each) do
+    WebMock.stub_request(:post, TRACES_URI)
+  end
 end


### PR DESCRIPTION
Adds a Delivery class with one method `deliver(headers, body)`

This will be used in the next PR for making empty requests for updated probability values