### PR TITLE
Fix Task spec flakes

### DIFF
--- a/spec/bugsnag_performance/task_spec.rb
+++ b/spec/bugsnag_performance/task_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe BugsnagPerformance::Task do
 
   context "#wait" do
     it "waits for the task to finish" do
-      subject.schedule(0.01)
+      subject.schedule(0.1)
       expect(callback).not_to have_received(:call)
 
       subject.wait
@@ -119,7 +119,7 @@ RSpec.describe BugsnagPerformance::Task do
     end
 
     it "does nothing if called after the task has finished" do
-      subject.schedule(0.01)
+      subject.schedule(0.1)
       expect(callback).not_to have_received(:call)
 
       subject.wait


### PR DESCRIPTION
These seem to have gotten worse somehow - originally I ran them hundreds of times without failure but now they fail reliably every few runs

Increasing the time until the task runs fixes the flake as it's caused by the task running before the assertion runs