### PR TITLE
Add SpanExporter#disable! to stop exporting spans

### DIFF
--- a/lib/bugsnag_performance/span_exporter.rb
+++ b/lib/bugsnag_performance/span_exporter.rb
@@ -14,9 +14,16 @@ module BugsnagPerformance
       @delivery = delivery
       @payload_encoder = payload_encoder
       @sampling_header_encoder = sampling_header_encoder
+      @disabled = false
+    end
+
+    def disable!
+      @disabled = true
     end
 
     def export(span_data, timeout: nil)
+      return OpenTelemetry::SDK::Trace::Export::SUCCESS if @disabled
+
       with_timeout(timeout) do
         headers = {}
         sampling_header = @sampling_header_encoder.encode(span_data)

--- a/spec/bugsnag_performance/span_exporter_spec.rb
+++ b/spec/bugsnag_performance/span_exporter_spec.rb
@@ -171,4 +171,13 @@ RSpec.describe BugsnagPerformance::SpanExporter do
     expect(logger_output).to include("[BugsnagPerformance] Failed to deliver trace to BugSnag.")
     expect(logger_output).to include("execution expired (Timeout::Error)")
   end
+
+  it "does not export spans when disabled" do
+    subject.disable!
+    status = subject.export([make_span])
+
+    expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    expect(subject).not_to have_sent_trace
+    expect(logger_output).to be_empty
+  end
 end


### PR DESCRIPTION
This provides a way to stop exporting spans if e.g. the release stage is not in the enabled release stages