### PR TITLE
Use correct status for export timeouts

### DIFF
--- a/lib/bugsnag_performance/span_exporter.rb
+++ b/lib/bugsnag_performance/span_exporter.rb
@@ -48,6 +48,8 @@ module BugsnagPerformance
       @logger.error("[BugsnagPerformance] Failed to deliver trace to BugSnag.")
       @logger.error(exception)
 
+      return OpenTelemetry::SDK::Trace::Export::TIMEOUT if exception.is_a?(Timeout::Error)
+
       OpenTelemetry::SDK::Trace::Export::FAILURE
     end
 


### PR DESCRIPTION
Currently we always return `OpenTelemetry::SDK::Trace::Export::FAILURE` when exporting fails, but we should be returning `OpenTelemetry::SDK::Trace::Export::TIMEOUT` when it times out