### PR TITLE
Rename gem to "bugsnag_performance"

### DIFF
--- a/bugsnag-performance.gemspec
+++ b/bugsnag-performance.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/bugsnag_performance/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "bugsnag-performance"
+  spec.name = "bugsnag_performance"
   spec.version = BugsnagPerformance::VERSION
   spec.authors = ["BugSnag"]
   spec.email = ["notifiers@bugsnag.com"]

--- a/features/fixtures/basic/app/Gemfile
+++ b/features/fixtures/basic/app/Gemfile
@@ -8,4 +8,4 @@ unless otel_sdk_version.nil? || otel_sdk_version.empty? || otel_sdk_version == "
   gem "opentelemetry-sdk", otel_sdk_version
 end
 
-gem "bugsnag-performance", path: "/bugsnag-performance"
+gem "bugsnag_performance", path: "/bugsnag-performance"

--- a/features/fixtures/bugsnag-errors/app/Gemfile
+++ b/features/fixtures/bugsnag-errors/app/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "bugsnag"
-gem "bugsnag-performance", path: "/bugsnag-performance"
+gem "bugsnag_performance", path: "/bugsnag-performance"


### PR DESCRIPTION
RubyGems recommend using underscores when multiple words are `PascalCased` and hyphens when they are `Nested::Modules`

As we expose `BugsnagPerformance`, the gem name should therefore be "bugsnag_performance" not "bugsnag-performance"

https://guides.rubygems.org/name-your-gem/