### PR TITLE
Remove 'use_managed_quota' from configuration

### DIFF
--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -9,7 +9,6 @@ module BugsnagPerformance
     attr_accessor :app_version
     attr_accessor :release_stage
     attr_accessor :enabled_release_stages
-    attr_accessor :use_managed_quota
 
     attr_writer :endpoint
 
@@ -20,7 +19,6 @@ module BugsnagPerformance
       @api_key = fetch(errors_configuration, :api_key, env: "BUGSNAG_PERFORMANCE_API_KEY")
       @app_version = fetch(errors_configuration, :app_version)
       @release_stage = fetch(errors_configuration, :release_stage, env: "BUGSNAG_PERFORMANCE_RELEASE_STAGE", default: "production")
-      @use_managed_quota = true
 
       @enabled_release_stages = fetch(errors_configuration, :enabled_release_stages, env: "BUGSNAG_PERFORMANCE_ENABLED_RELEASE_STAGES")
 

--- a/lib/bugsnag_performance/internal/configuration_validator.rb
+++ b/lib/bugsnag_performance/internal/configuration_validator.rb
@@ -16,7 +16,6 @@ module BugsnagPerformance
         validate_string(:app_version, optional: true)
         validate_string(:release_stage, optional: true)
         validate_array(:enabled_release_stages, "non-empty strings", optional: true, &method(:valid_string?))
-        validate_boolean(:use_managed_quota, optional: false)
         valid_endpoint = validate_endpoint
 
         # if the endpoint is invalid then we shouldn't attempt to send traces
@@ -69,16 +68,6 @@ module BugsnagPerformance
           @valid_configuration.send("#{name}=", value)
         else
           @messages << "#{name} should be a non-empty string, got #{value.inspect}"
-        end
-      end
-
-      def validate_boolean(name, optional:)
-        value = @configuration.send(name)
-
-        if (value.nil? && optional) || value == true || value == false
-          @valid_configuration.send("#{name}=", value)
-        else
-          @messages << "#{name} should be a boolean, got #{value.inspect}"
         end
       end
 

--- a/spec/bugsnag_performance/configuration_spec.rb
+++ b/spec/bugsnag_performance/configuration_spec.rb
@@ -254,18 +254,4 @@ RSpec.describe BugsnagPerformance::Configuration do
       expect(subject.endpoint).to eq(endpoint)
     end
   end
-
-  context "use managed quota" do
-    it "is 'true' by default" do
-      expect(subject.use_managed_quota).to eq(true)
-    end
-
-    it "can be set to a valid value" do
-      use_managed_quota = false
-
-      subject.use_managed_quota = use_managed_quota
-
-      expect(subject.use_managed_quota).to eq(use_managed_quota)
-    end
-  end
 end

--- a/spec/bugsnag_performance/internal/configuration_validator_spec.rb
+++ b/spec/bugsnag_performance/internal/configuration_validator_spec.rb
@@ -233,41 +233,6 @@ RSpec.describe BugsnagPerformance::Internal::ConfigurationValidator do
     end
   end
 
-  context "use managed quota" do
-    it "is required" do
-      configuration.use_managed_quota = nil
-      result = subject.validate(configuration)
-
-      expect(result.messages).to eq([
-        "use_managed_quota should be a boolean, got nil",
-      ])
-
-      expect(result.valid?).to be(false)
-      expect(result.configuration.use_managed_quota).to be(true)
-    end
-
-    it "passes validation when set to a valid value" do
-      configuration.use_managed_quota = false
-      result = subject.validate(configuration)
-
-      expect(result.messages).to be_empty
-      expect(result.valid?).to be(true)
-      expect(result.configuration.use_managed_quota).to be(false)
-    end
-
-    it "fails validation when set to an invalid type" do
-      configuration.use_managed_quota = "falsey"
-      result = subject.validate(configuration)
-
-      expect(result.messages).to eq([
-        'use_managed_quota should be a boolean, got "falsey"',
-      ])
-
-      expect(result.valid?).to be(false)
-      expect(result.configuration.use_managed_quota).to be(true)
-    end
-  end
-
   context "endpoint" do
     it "is required" do
       configuration.endpoint = nil


### PR DESCRIPTION
We've decided to pivot away from this explicit configuration and rely on users setting their own sampler to use 'unmanaged mode' instead