### PR TITLE
Send unmanaged spans when a custom sampler is used

### DIFF
--- a/lib/bugsnag_performance/internal/delivery.rb
+++ b/lib/bugsnag_performance/internal/delivery.rb
@@ -3,6 +3,8 @@
 module BugsnagPerformance
   module Internal
     class Delivery
+      attr_reader :uri
+
       def initialize(configuration)
         @uri = URI(configuration.endpoint)
         @common_headers = {

--- a/lib/bugsnag_performance/internal/payload_encoder.rb
+++ b/lib/bugsnag_performance/internal/payload_encoder.rb
@@ -26,14 +26,9 @@ module BugsnagPerformance
         :SPAN_STATUS_UNSET,
         :SPAN_STATUS_ERROR
 
-      def initialize(sampler)
-        @sampler = sampler
-      end
-
       def encode(span_data)
         {
           resourceSpans: span_data
-            .filter { |span| @sampler.resample_span?(span) }
             .group_by(&:resource)
             .map do |resource, scope_spans|
               {

--- a/lib/bugsnag_performance/internal/span_exporter.rb
+++ b/lib/bugsnag_performance/internal/span_exporter.rb
@@ -7,35 +7,66 @@ module BugsnagPerformance
         logger,
         probability_manager,
         delivery,
+        sampler,
         payload_encoder,
         sampling_header_encoder
       )
         @logger = logger
         @probability_manager = probability_manager
         @delivery = delivery
+        @sampler = sampler
         @payload_encoder = payload_encoder
         @sampling_header_encoder = sampling_header_encoder
         @disabled = false
+        @unmanaged_mode = false
+        @logged_first_batch_destination = false
       end
 
       def disable!
         @disabled = true
       end
 
+      def unmanaged_mode!
+        @unmanaged_mode = true
+      end
+
+      def unmanaged_mode?
+        @unmanaged_mode
+      end
+
       def export(span_data, timeout: nil)
         return OpenTelemetry::SDK::Trace::Export::SUCCESS if @disabled
 
         with_timeout(timeout) do
-          headers = {}
-          sampling_header = @sampling_header_encoder.encode(span_data)
+          # ensure we're in the correct managed or unmanaged mode
+          maybe_enter_unmanaged_mode
+          managed_status = unmanaged_mode? ? "unmanaged" : "managed"
 
-          if sampling_header.nil?
-            @logger.warn("One or more spans are missing the 'bugsnag.sampling.p' attribute. This trace will be sent as 'unmanaged'.")
-          else
-            headers["Bugsnag-Span-Sampling"] = sampling_header
+          headers = {}
+
+          # resample the spans and attach the Bugsnag-Span-Sampling header only
+          # if we're in managed mode
+          unless unmanaged_mode?
+            span_data = span_data.filter { |span| @sampler.resample_span?(span) }
+
+            sampling_header = @sampling_header_encoder.encode(span_data)
+
+            if sampling_header.nil?
+              @logger.warn("One or more spans are missing the 'bugsnag.sampling.p' attribute. This trace will be sent as unmanaged")
+              managed_status = "unmanaged"
+            else
+              headers["Bugsnag-Span-Sampling"] = sampling_header
+            end
           end
 
           body = JSON.generate(@payload_encoder.encode(span_data))
+
+          # log whether we're sending managed or unmanaged spans on the first
+          # batch only
+          unless @logged_first_batch_destination
+            @logger.info("Sending #{managed_status} spans to #{@delivery.uri}")
+            @logged_first_batch_destination = true
+          end
 
           response = @delivery.deliver(headers, body)
 
@@ -63,6 +94,18 @@ module BugsnagPerformance
       end
 
       private
+
+      def maybe_enter_unmanaged_mode
+        # we're in unmanaged mode already so don't need to do anything
+        return if unmanaged_mode?
+
+        # our sampler is in use so we're in managed mode
+        return if OpenTelemetry.tracer_provider.sampler.is_a?(Sampler)
+
+        # the user has changed the sampler from ours to a custom one; enter
+        # unmanaged mode
+        unmanaged_mode!
+      end
 
       def with_timeout(timeout, &block)
         if timeout.nil?


### PR DESCRIPTION
When the user has set their own sampler, either via the `OTEL_TRACES_SAMPLER` environment variable or manually in code, we will now send unmanaged trace payloads

On the first batch delivery we'll log a message letting the user know which mode we're sending spans in

We can't write Maze Runner tests for this without a span processor that attaches the p value attribute separately to the sampler — that will come in a future PR