### PR TITLE
Add ProbabilityAttributeSpanProcessor

### DIFF
--- a/lib/bugsnag_performance.rb
+++ b/lib/bugsnag_performance.rb
@@ -23,6 +23,7 @@ require_relative "bugsnag_performance/internal/probability_manager"
 require_relative "bugsnag_performance/internal/configuration_validator"
 require_relative "bugsnag_performance/internal/sampling_header_encoder"
 require_relative "bugsnag_performance/internal/nil_errors_configuration"
+require_relative "bugsnag_performance/internal/probability_attribute_span_processor"
 
 module BugsnagPerformance
   def self.configure(&block)
@@ -82,6 +83,12 @@ module BugsnagPerformance
       # add batch processor with bugsnag exporter to send payloads
       otel_configurator.add_span_processor(
         OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
+      )
+
+      # ensure the "bugsnag.sampling.p" attribute is set on all spans even when
+      # our sampler is not in use
+      otel_configurator.add_span_processor(
+        Internal::ProbabilityAttributeSpanProcessor.new(probability_manager)
       )
     end
 

--- a/lib/bugsnag_performance/internal/probability_attribute_span_processor.rb
+++ b/lib/bugsnag_performance/internal/probability_attribute_span_processor.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module BugsnagPerformance
+  module Internal
+    class ProbabilityAttributeSpanProcessor
+      def initialize(probability_manager)
+        @probability_manager = probability_manager
+      end
+
+      def on_start(span, parent_context)
+        # avoid overwriting the attribute if the sampler has already set it
+        if span.attributes.nil? || span.attributes["bugsnag.sampling.p"].nil?
+          span.set_attribute("bugsnag.sampling.p", @probability_manager.probability)
+        end
+
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+
+      def on_finish(span)
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+
+      def force_flush(timeout: nil)
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+
+      def shutdown(timeout: nil)
+        OpenTelemetry::SDK::Trace::Export::SUCCESS
+      end
+    end
+  end
+end

--- a/spec/bugsnag_performance/internal/probability_attribute_span_processor_spec.rb
+++ b/spec/bugsnag_performance/internal/probability_attribute_span_processor_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe BugsnagPerformance::Internal::ProbabilityAttributeSpanProcessor do
+  subject { BugsnagPerformance::Internal::ProbabilityAttributeSpanProcessor.new(probability_manager) }
+
+  let(:probability_manager) { BugsnagPerformance::Internal::ProbabilityManager.new(probability_fetcher) }
+  let(:probability_fetcher) { instance_double(BugsnagPerformance::Internal::ProbabilityFetcher, { on_new_probability: nil, stale_in: nil }) }
+
+  let(:span) do
+    span = OpenTelemetry::SDK::Trace::Span.new(
+      OpenTelemetry::Trace::SpanContext.new,
+      OpenTelemetry::Context.empty,
+      OpenTelemetry::Trace::Span::INVALID,
+      "name",
+      OpenTelemetry::Trace::SpanKind::INTERNAL,
+      nil,
+      OpenTelemetry::SDK::Trace::SpanLimits.new(
+        attribute_count_limit: 10,
+        event_count_limit: 10,
+        link_count_limit: 10,
+        event_attribute_count_limit: 10,
+        link_attribute_count_limit: 10,
+        attribute_length_limit: 32,
+        event_attribute_length_limit: 32
+      ),
+      [],
+      nil,
+      nil,
+      Time.now,
+      nil,
+      nil
+    )
+  end
+
+  context "#on_start" do
+    [0.0, 0.1, 0.25, 0.33, 0.4, 0.5, 0.66, 0.75, 0.8, 0.99, 1.0].each do |probability|
+      it "adds the 'bugsnag.sampling.p' attribute to spans with value of #{probability}" do
+        probability_manager.probability = probability
+
+        status = subject.on_start(span, OpenTelemetry::Context.empty)
+
+        expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+        expect(span.attributes).to eq({ "bugsnag.sampling.p" => probability })
+      end
+    end
+
+    it "does not overwrite an existing 'bugsnag.sampling.p' attribute" do
+      span.set_attribute("bugsnag.sampling.p", 0.1)
+
+      probability_manager.probability = 0.5
+      status = subject.on_start(span, OpenTelemetry::Context.empty)
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(span.attributes).to eq({ "bugsnag.sampling.p" => 0.1 })
+    end
+
+    it "does not overwrite other existing attributes" do
+      span.add_attributes({
+        "some.other.attribute" => [1, 2, 3],
+        "an.other.attribute" => "abc",
+      })
+
+      pp span.attributes
+
+      probability_manager.probability = 0.6
+      status = subject.on_start(span, OpenTelemetry::Context.empty)
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(span.attributes).to eq({
+        "some.other.attribute" => [1, 2, 3],
+        "an.other.attribute" => "abc",
+        "bugsnag.sampling.p" => 0.6
+      })
+    end
+  end
+
+  context "#on_finish" do
+    it "returns successfully" do
+      status = subject.on_finish(span)
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    end
+  end
+
+  context "#force_flush" do
+    it "returns successfully" do
+      status = subject.force_flush
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    end
+
+    it "returns successfully with a timeout" do
+      status = subject.force_flush(timeout: 1)
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    end
+  end
+
+  context "#shutdown" do
+    it "returns successfully" do
+      status = subject.shutdown
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    end
+
+    it "returns successfully with a timeout" do
+      status = subject.shutdown(timeout: 1)
+
+      expect(status).to be(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+    end
+  end
+end

--- a/spec/bugsnag_performance_spec.rb
+++ b/spec/bugsnag_performance_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe BugsnagPerformance do
       allow(open_telemetry_sdk).to receive(:configure).and_yield(open_telemetry_configurator)
       allow(open_telemetry_configurator).to receive(:resource=).with(an_instance_of(OpenTelemetry::SDK::Resources::Resource))
       allow(open_telemetry_configurator).to receive(:add_span_processor).with(an_instance_of(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor))
+      allow(open_telemetry_configurator).to receive(:add_span_processor).with(an_instance_of(BugsnagPerformance::Internal::ProbabilityAttributeSpanProcessor))
 
       allow(open_telemetry).to receive(:tracer_provider).and_return(open_telemetry_tracer_provider)
       allow(open_telemetry).to receive(:logger).and_return(logger)


### PR DESCRIPTION
This handles adding the p value attribute to all spans even when our sampler is not being used

Our sampler still needs to handle setting the p value when it is being used because otherwise the values could differ between the time the sampler makes its sampling decision and the time this new span processor runs