### PR TITLE
Add user agent header to delivery

### DIFF
--- a/lib/bugsnag_performance/internal/delivery.rb
+++ b/lib/bugsnag_performance/internal/delivery.rb
@@ -8,6 +8,7 @@ module BugsnagPerformance
       def initialize(configuration)
         @uri = URI(configuration.endpoint)
         @common_headers = {
+          "User-Agent" => "Ruby Bugsnag Performance SDK v#{BugsnagPerformance::VERSION}",
           "Bugsnag-Api-Key" => configuration.api_key,
           "Content-Type" => "application/json",
         }.freeze

--- a/spec/bugsnag_performance/internal/delivery_spec.rb
+++ b/spec/bugsnag_performance/internal/delivery_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe BugsnagPerformance::Internal::Delivery do
       response = subject.deliver({ "header" => "yes" }, "hello")
 
       expect(response).to be_successful
+      expect(WebMock).to have_requested(:post, TRACES_URI)
+        .with(
+          body: "hello",
+          headers: {
+            "header" => "yes",
+            "Content-Type" => "application/json",
+            "Bugsnag-Api-Key" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "User-Agent" => "Ruby Bugsnag Performance SDK v#{BugsnagPerformance::VERSION}",
+          }
+        ).once
     end
   end
 

--- a/spec/bugsnag_performance/internal/span_exporter_spec.rb
+++ b/spec/bugsnag_performance/internal/span_exporter_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe BugsnagPerformance::Internal::SpanExporter do
       expect(headers["Bugsnag-Api-Key"]).to eq("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
       expect(headers["Bugsnag-Sent-At"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/)
       expect(headers["Content-Type"]).to eq("application/json")
+      expect(headers["User-Agent"]).to eq("Ruby Bugsnag Performance SDK v#{BugsnagPerformance::VERSION}")
     }
     expect(logger_output).to include("Sending managed spans to https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.otlp.bugsnag.com/v1/traces")
   end


### PR DESCRIPTION
Adds a user agent header to all requests with the library name & version