### PR TITLE
Read bugsnag errors environment variables

### DIFF
--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -17,7 +17,7 @@ module BugsnagPerformance
       self.logger = errors_configuration.logger || OpenTelemetry.logger
 
       @api_key = fetch(errors_configuration, :api_key, env: "BUGSNAG_PERFORMANCE_API_KEY")
-      @app_version = fetch(errors_configuration, :app_version)
+      @app_version = fetch(errors_configuration, :app_version, env: "BUGSNAG_PERFORMANCE_APP_VERSION")
       @release_stage = fetch(errors_configuration, :release_stage, env: "BUGSNAG_PERFORMANCE_RELEASE_STAGE", default: "production")
 
       @enabled_release_stages = fetch(errors_configuration, :enabled_release_stages, env: "BUGSNAG_PERFORMANCE_ENABLED_RELEASE_STAGES")

--- a/lib/bugsnag_performance/internal/nil_errors_configuration.rb
+++ b/lib/bugsnag_performance/internal/nil_errors_configuration.rb
@@ -15,7 +15,9 @@ module BugsnagPerformance
         # if bugsnag errors is not installed we still want to read from the
         # environment variables it supports
         @api_key = ENV["BUGSNAG_API_KEY"]
+        @app_version = ENV["BUGSNAG_APP_VERSION"]
         @release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
+        @enabled_release_stages = ENV["BUGSNAG_ENABLED_RELEASE_STAGES"]
       end
     end
   end


### PR DESCRIPTION
When bugsnag errors is not installed we still want to read its environment variables so that the performance library can always be configured with `BUGSNAG_API_KEY` & friends

I've also added environment variables for `app_version` and `enabled_release_stages` as it seemed odd to leave them out and we're intending on adding them to bugsnag errors at some point in the future