### PR TITLE
Restore Bugsnag-Sent-At header

### DIFF
--- a/features/support/maze_runner_configuration.rb
+++ b/features/support/maze_runner_configuration.rb
@@ -14,8 +14,6 @@ Maze.hooks.before_all do
 
   # we don't need to send the integrity header
   Maze.config.enforce_bugsnag_integrity = false
-  # TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-  Maze.config.skip_default_validation('trace')
 
   BugsnagPerformanceMazeRunner::Fixtures.new($logger).install_gem
 end

--- a/lib/bugsnag_performance/internal/delivery.rb
+++ b/lib/bugsnag_performance/internal/delivery.rb
@@ -17,8 +17,7 @@ module BugsnagPerformance
       def deliver(headers, body)
         headers = headers.merge(
           @common_headers,
-        # TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-        #  { "Bugsnag-Sent-At" => Time.now.utc.iso8601(3) },
+          { "Bugsnag-Sent-At" => Time.now.utc.iso8601(3) },
         )
 
         raw_response = OpenTelemetry::Common::Utilities.untraced do

--- a/spec/bugsnag_performance/internal/span_exporter_spec.rb
+++ b/spec/bugsnag_performance/internal/span_exporter_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe BugsnagPerformance::Internal::SpanExporter do
     expect(subject).to have_sent_trace { |headers:, **|
       expect(headers["Bugsnag-Span-Sampling"]).to eq("1.0:1")
       expect(headers["Bugsnag-Api-Key"]).to eq("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-      # TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-      #expect(headers["Bugsnag-Sent-At"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/)
+      expect(headers["Bugsnag-Sent-At"]).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z/)
       expect(headers["Content-Type"]).to eq("application/json")
       expect(headers["User-Agent"]).to eq("#{BugsnagPerformance::SDK_NAME} v#{BugsnagPerformance::VERSION}")
     }


### PR DESCRIPTION
Related Pipeline ticket was finished, so `Bugsnag-Sent-At` header is restored.