### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ maze_output
 temp-bugsnag-performance
 
 *.gem
+
+# IDEs
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 1.1.0 (2025-06-??)
+
+### Enhancements
+
+* Set default endpoints based on API key
+[#51](https://github.com/bugsnag/bugsnag-ruby/pull/51)
+
 ## 1.0.0 (2024-12-09)
 
 ### Enhancements

--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -59,6 +59,8 @@ module BugsnagPerformance
 
     attr_writer :endpoint
 
+    HUB_PREFIX = "00000"
+
     def initialize(errors_configuration)
       @open_telemetry_configure_block = proc { |c| }
       self.logger = errors_configuration.logger || OpenTelemetry.logger
@@ -92,7 +94,7 @@ module BugsnagPerformance
 
     # The URL to send traces to
     #
-    # If not set this defaults to "https://<api_key>.otlp.bugsnag.com/v1/traces"
+    # If not set this defaults to "https://<api_key>.otlp.bugsnag.com/v1/traces" or "https://<api_key>.otlp.insighthub.smartbear.com/v1/traces", depending on the API key
     #
     # @return [String, nil]
     def endpoint
@@ -104,7 +106,12 @@ module BugsnagPerformance
         # if there's no API key then we can't construct the default URL
         nil
       else
-        "https://#{@api_key}.otlp.bugsnag.com/v1/traces"
+        instance = if hub_api_key?
+          "insighthub.smartbear.com"
+        else
+          "bugsnag.com"
+        end
+        "https://#{@api_key}.otlp.#{instance}/v1/traces"
       end
     end
 
@@ -133,6 +140,10 @@ module BugsnagPerformance
       return value unless value.nil?
 
       default
+    end
+
+    def hub_api_key?
+      @api_key&.start_with?(HUB_PREFIX)
     end
   end
 end

--- a/lib/bugsnag_performance/configuration.rb
+++ b/lib/bugsnag_performance/configuration.rb
@@ -143,7 +143,7 @@ module BugsnagPerformance
     end
 
     def hub_api_key?
-      @api_key&.start_with?(HUB_PREFIX)
+      @api_key.is_a?(String) && @api_key&.start_with?(HUB_PREFIX)
     end
   end
 end

--- a/spec/bugsnag_performance/configuration_spec.rb
+++ b/spec/bugsnag_performance/configuration_spec.rb
@@ -335,10 +335,16 @@ RSpec.describe BugsnagPerformance::Configuration do
       expect(subject.endpoint).to be_nil
     end
 
-    it "is the default URL if API key is set" do
+    it "is the default non-hub URL if a non-hub API key is set" do
       subject.api_key = "1234567890abcdef1234567890abcdef"
 
       expect(subject.endpoint).to eq("https://#{subject.api_key}.otlp.bugsnag.com/v1/traces")
+    end
+
+    it "is the default hub URL if a hub API key is set" do
+      subject.api_key = "0000067890abcdef1234567890abcdef"
+
+      expect(subject.endpoint).to eq("https://#{subject.api_key}.otlp.insighthub.smartbear.com/v1/traces")
     end
 
     it "can be set to a valid value" do


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to *.insighthub.smartbear.com if the API key starts with `00000`.

## Testing

Unit tests updated.